### PR TITLE
Create answer command and update score 

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -14,5 +14,6 @@ public class Messages {
             + " session";
     public static final String MESSAGE_INVALID_COMMAND_INSIDE_TEST_SESSION = "This command is not valid inside a test"
             + " session";
-    public static final String MESSAGE_INVALID_ANSWER_COMMAND = "Answer Command is valid only when a question is displayed";
+    public static final String MESSAGE_INVALID_ANSWER_COMMAND = "Answer Command is valid only when a question is displayed"
+            + " in a test session";
 }

--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -14,5 +14,5 @@ public class Messages {
             + " session";
     public static final String MESSAGE_INVALID_COMMAND_INSIDE_TEST_SESSION = "This command is not valid inside a test"
             + " session";
-    public static final String MESSAGE_INVALID_ANSWER_COMMAND = "Answer Command is valid only when a question is displayed";
+    public static final String MESSAGE_INVALID_ANSWER_COMMAND = "Answer command is valid only when a question is displayed";
 }

--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -14,6 +14,5 @@ public class Messages {
             + " session";
     public static final String MESSAGE_INVALID_COMMAND_INSIDE_TEST_SESSION = "This command is not valid inside a test"
             + " session";
-    public static final String MESSAGE_INVALID_ANSWER_COMMAND = "Answer Command is valid only when a question is displayed"
-            + " in a test session";
+    public static final String MESSAGE_INVALID_ANSWER_COMMAND = "Answer Command is valid only when a question is displayed";
 }

--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -14,5 +14,6 @@ public class Messages {
             + " session";
     public static final String MESSAGE_INVALID_COMMAND_INSIDE_TEST_SESSION = "This command is not valid inside a test"
             + " session";
-    public static final String MESSAGE_INVALID_ANSWER_COMMAND = "Answer command is valid only when a question is displayed";
+    public static final String MESSAGE_INVALID_ANSWER_COMMAND = "Answer command is valid only when a question is "
+            + "displayed";
 }

--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -14,5 +14,5 @@ public class Messages {
             + " session";
     public static final String MESSAGE_INVALID_COMMAND_INSIDE_TEST_SESSION = "This command is not valid inside a test"
             + " session";
-
+    public static final String MESSAGE_INVALID_ANSWER_COMMAND = "Answer Command is valid only when a question is displayed";
 }

--- a/src/main/java/seedu/address/logic/AnswerCommandResultType.java
+++ b/src/main/java/seedu/address/logic/AnswerCommandResultType.java
@@ -1,0 +1,8 @@
+package seedu.address.logic;
+
+/*
+ * Define the different types that the result of a AnswerCommand can take on
+ */
+public enum AnswerCommandResultType {
+    NOT_ANSWER_COMMAND, ANSWER_CORRECT, ANSWER_WRONG
+}

--- a/src/main/java/seedu/address/logic/AnswerCommandResultType.java
+++ b/src/main/java/seedu/address/logic/AnswerCommandResultType.java
@@ -1,7 +1,7 @@
 package seedu.address.logic;
 
 /*
- * Define the different types that the result of a AnswerCommand can take on
+ * Define the different types that the result of a AnswerCommand can take on.
  */
 public enum AnswerCommandResultType {
     NOT_ANSWER_COMMAND, ANSWER_CORRECT, ANSWER_WRONG

--- a/src/main/java/seedu/address/logic/AnswerCommandResultType.java
+++ b/src/main/java/seedu/address/logic/AnswerCommandResultType.java
@@ -1,6 +1,6 @@
 package seedu.address.logic;
 
-/*
+/**
  * Define the different types that the result of a AnswerCommand can take on.
  */
 public enum AnswerCommandResultType {

--- a/src/main/java/seedu/address/logic/commands/AnswerCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AnswerCommand.java
@@ -39,7 +39,6 @@ public class AnswerCommand extends Command {
     @Override
     public CommandResult execute(Model model, CommandHistory history) throws CommandException {
         requireNonNull(model);
-        List<Card> lastShownList = model.getFilteredCards();
 
         if (!model.checkIfInsideTestSession()) {
             throw new CommandException(Messages.MESSAGE_INVALID_COMMAND_OUTSIDE_TEST_SESSION);
@@ -48,7 +47,7 @@ public class AnswerCommand extends Command {
             throw new CommandException(Messages.MESSAGE_INVALID_ANSWER_COMMAND);
         }
         model.setCardAsAnswered();
-        Card cardToMark = lastShownList.get(0);
+        Card cardToMark = model.getCurrentTestedCard();
 
         boolean isAttemptCorrect = model.markAttemptedAnswer(attemptedAnswer);
 

--- a/src/main/java/seedu/address/logic/commands/AnswerCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AnswerCommand.java
@@ -5,6 +5,7 @@ import static java.util.Objects.requireNonNull;
 import seedu.address.commons.core.Messages;
 import seedu.address.logic.AnswerCommandResultType;
 import seedu.address.logic.CommandHistory;
+import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.card.Answer;
 
@@ -31,11 +32,13 @@ public class AnswerCommand extends Command {
     }
 
     @Override
-    public CommandResult execute(Model model, CommandHistory history) {
+    public CommandResult execute(Model model, CommandHistory history) throws CommandException {
         requireNonNull(model);
+        if (!model.checkIfInsideTestSession()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_COMMAND_OUTSIDE_TEST_SESSION);
+        }
 
         boolean isAttemptCorrect = model.markAttemptedAnswer(attemptedAnswer);
-
         if (isAttemptCorrect) {
             return new CommandResult(MESSAGE_ANSWER_SUCCESS, false, false, null, false, AnswerCommandResultType.ANSWER_CORRECT);
         } else {

--- a/src/main/java/seedu/address/logic/commands/AnswerCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AnswerCommand.java
@@ -10,8 +10,9 @@ import seedu.address.model.Model;
 import seedu.address.model.card.Answer;
 
 /**
- * Finds and lists all cards in card folder whose question contains any of the argument keywords.
- * Keyword matching is case insensitive.
+ * Allows user to input an answer for the currently displayed card, compares it with the
+ * correct answer in that card and tell the user if it is correct or wrong.
+ * Answer matching is case insensitive.
  */
 public class AnswerCommand extends Command {
 
@@ -42,6 +43,9 @@ public class AnswerCommand extends Command {
         model.setCardAsAnswered();
 
         boolean isAttemptCorrect = model.markAttemptedAnswer(attemptedAnswer);
+
+        //TODO: Call method to update score for this card
+
         if (isAttemptCorrect) {
             return new CommandResult(MESSAGE_ANSWER_SUCCESS, false, false, null, false, AnswerCommandResultType.ANSWER_CORRECT);
         } else {

--- a/src/main/java/seedu/address/logic/commands/AnswerCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AnswerCommand.java
@@ -1,6 +1,9 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_CARDS;
+
+import java.util.List;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.logic.AnswerCommandResultType;
@@ -8,6 +11,8 @@ import seedu.address.logic.CommandHistory;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.card.Answer;
+import seedu.address.model.card.Card;
+import seedu.address.model.card.Score;
 
 /**
  * Allows user to input an answer for the currently displayed card, compares it with the
@@ -34,6 +39,8 @@ public class AnswerCommand extends Command {
     @Override
     public CommandResult execute(Model model, CommandHistory history) throws CommandException {
         requireNonNull(model);
+        List<Card> lastShownList = model.getFilteredCards();
+
         if (!model.checkIfInsideTestSession()) {
             throw new CommandException(Messages.MESSAGE_INVALID_COMMAND_OUTSIDE_TEST_SESSION);
         }
@@ -41,11 +48,14 @@ public class AnswerCommand extends Command {
             throw new CommandException(Messages.MESSAGE_INVALID_ANSWER_COMMAND);
         }
         model.setCardAsAnswered();
+        Card cardToMark = lastShownList.get(0);
 
         boolean isAttemptCorrect = model.markAttemptedAnswer(attemptedAnswer);
 
-        //TODO: Call method to update score for this card
-
+        Card scoredCard = createScoredCard(cardToMark, isAttemptCorrect);
+        model.setCard(cardToMark, scoredCard);
+        model.updateFilteredCard(PREDICATE_SHOW_ALL_CARDS);
+        model.commitActiveCardFolder();
         if (isAttemptCorrect) {
             return new CommandResult(MESSAGE_ANSWER_SUCCESS, false, false, null,
                     false, AnswerCommandResultType.ANSWER_CORRECT);
@@ -53,6 +63,17 @@ public class AnswerCommand extends Command {
             return new CommandResult(MESSAGE_ANSWER_SUCCESS, false, false, null,
                     false, AnswerCommandResultType.ANSWER_WRONG);
         }
+    }
+    private static Card createScoredCard(Card cardToMark, boolean markCorrect) {
+        Score newScore;
+        if (markCorrect) {
+            newScore = new Score(cardToMark.getScore().correctAttempts + 1,
+                    cardToMark.getScore().totalAttempts + 1);
+        } else {
+            newScore = new Score(cardToMark.getScore().correctAttempts,
+                    cardToMark.getScore().totalAttempts + 1);
+        }
+        return new Card(cardToMark.getQuestion(), cardToMark.getAnswer(), newScore, cardToMark.getHints());
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/AnswerCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AnswerCommand.java
@@ -18,8 +18,7 @@ public class AnswerCommand extends Command {
     public static final String COMMAND_WORD = "ans";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": User inputs an answer for the"
-            + " currently displayed card. This command is valid only in an active test session"
-            + " and a card is currently being displayed.\n"
+            + " currently displayed card.\n"
             + "Parameters: ANSWER \n"
             + "Example: " + COMMAND_WORD + " Mitochondrion";
 
@@ -37,6 +36,10 @@ public class AnswerCommand extends Command {
         if (!model.checkIfInsideTestSession()) {
             throw new CommandException(Messages.MESSAGE_INVALID_COMMAND_OUTSIDE_TEST_SESSION);
         }
+        if (model.checkIfCardAlreadyAnswered()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_ANSWER_COMMAND);
+        }
+        model.setCardAsAnswered();
 
         boolean isAttemptCorrect = model.markAttemptedAnswer(attemptedAnswer);
         if (isAttemptCorrect) {

--- a/src/main/java/seedu/address/logic/commands/AnswerCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AnswerCommand.java
@@ -64,6 +64,13 @@ public class AnswerCommand extends Command {
                     false, AnswerCommandResultType.ANSWER_WRONG);
         }
     }
+
+    /**
+     *
+     * @param cardToMark {@code Card} which is being marked correct or wrong
+     * @param markCorrect Boolean representing if card should be graded correct or wrong
+     * @return Card created with new score
+     */
     private static Card createScoredCard(Card cardToMark, boolean markCorrect) {
         Score newScore;
         if (markCorrect) {

--- a/src/main/java/seedu/address/logic/commands/AnswerCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AnswerCommand.java
@@ -1,0 +1,43 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.logic.CommandHistory;
+import seedu.address.model.Model;
+
+/**
+ * Finds and lists all cards in card folder whose question contains any of the argument keywords.
+ * Keyword matching is case insensitive.
+ */
+public class AnswerCommand extends Command {
+
+    public static final String COMMAND_WORD = "ans";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": User inputs an answer for the"
+            + " currently displayed card. This command is valid only in an active test session"
+            + " and a card is currently being displayed.\n"
+            + "Parameters: ANSWER \n"
+            + "Example: " + COMMAND_WORD + " Mitochondrion";
+
+    private final String attemptedAnswer;
+
+    public AnswerCommand(String attemptedAnswer) {
+        this.attemptedAnswer = attemptedAnswer;
+    }
+
+    @Override
+    public CommandResult execute(Model model, CommandHistory history) {
+        requireNonNull(model);
+        //Change implementation later
+        return new CommandResult(
+                String.format(Messages.MESSAGE_CARDS_LISTED_OVERVIEW, model.getFilteredCards().size()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof AnswerCommand // instanceof handles nulls
+                && attemptedAnswer.equals(((AnswerCommand) other).attemptedAnswer)); // state check
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/AnswerCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AnswerCommand.java
@@ -3,6 +3,7 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 
 import seedu.address.commons.core.Messages;
+import seedu.address.logic.AnswerCommandResultType;
 import seedu.address.logic.CommandHistory;
 import seedu.address.model.Model;
 import seedu.address.model.card.Answer;
@@ -21,6 +22,8 @@ public class AnswerCommand extends Command {
             + "Parameters: ANSWER \n"
             + "Example: " + COMMAND_WORD + " Mitochondrion";
 
+    public static final String MESSAGE_ANSWER_SUCCESS = "Answer sent successfully";
+
     private final Answer attemptedAnswer;
 
     public AnswerCommand(Answer attemptedAnswer) {
@@ -30,9 +33,14 @@ public class AnswerCommand extends Command {
     @Override
     public CommandResult execute(Model model, CommandHistory history) {
         requireNonNull(model);
-        //Change implementation later
-        return new CommandResult(
-                String.format(Messages.MESSAGE_CARDS_LISTED_OVERVIEW, model.getFilteredCards().size()));
+
+        boolean isAttemptCorrect = model.markAttemptedAnswer(attemptedAnswer);
+
+        if (isAttemptCorrect) {
+            return new CommandResult(MESSAGE_ANSWER_SUCCESS, false, false, null, false, AnswerCommandResultType.ANSWER_CORRECT);
+        } else {
+            return new CommandResult(MESSAGE_ANSWER_SUCCESS, false, false, null, false, AnswerCommandResultType.ANSWER_WRONG);
+        }
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/AnswerCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AnswerCommand.java
@@ -47,9 +47,11 @@ public class AnswerCommand extends Command {
         //TODO: Call method to update score for this card
 
         if (isAttemptCorrect) {
-            return new CommandResult(MESSAGE_ANSWER_SUCCESS, false, false, null, false, AnswerCommandResultType.ANSWER_CORRECT);
+            return new CommandResult(MESSAGE_ANSWER_SUCCESS, false, false, null,
+                    false, AnswerCommandResultType.ANSWER_CORRECT);
         } else {
-            return new CommandResult(MESSAGE_ANSWER_SUCCESS, false, false, null, false, AnswerCommandResultType.ANSWER_WRONG);
+            return new CommandResult(MESSAGE_ANSWER_SUCCESS, false, false, null,
+                    false, AnswerCommandResultType.ANSWER_WRONG);
         }
     }
 

--- a/src/main/java/seedu/address/logic/commands/AnswerCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AnswerCommand.java
@@ -5,6 +5,7 @@ import static java.util.Objects.requireNonNull;
 import seedu.address.commons.core.Messages;
 import seedu.address.logic.CommandHistory;
 import seedu.address.model.Model;
+import seedu.address.model.card.Answer;
 
 /**
  * Finds and lists all cards in card folder whose question contains any of the argument keywords.
@@ -20,9 +21,9 @@ public class AnswerCommand extends Command {
             + "Parameters: ANSWER \n"
             + "Example: " + COMMAND_WORD + " Mitochondrion";
 
-    private final String attemptedAnswer;
+    private final Answer attemptedAnswer;
 
-    public AnswerCommand(String attemptedAnswer) {
+    public AnswerCommand(Answer attemptedAnswer) {
         this.attemptedAnswer = attemptedAnswer;
     }
 

--- a/src/main/java/seedu/address/logic/commands/AnswerCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AnswerCommand.java
@@ -3,8 +3,6 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_CARDS;
 
-import java.util.List;
-
 import seedu.address.commons.core.Messages;
 import seedu.address.logic.AnswerCommandResultType;
 import seedu.address.logic.CommandHistory;

--- a/src/main/java/seedu/address/logic/commands/CommandResult.java
+++ b/src/main/java/seedu/address/logic/commands/CommandResult.java
@@ -4,7 +4,9 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.Objects;
 
+import seedu.address.commons.core.Messages;
 import seedu.address.logic.AnswerCommandResultType;
+import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.card.Card;
 
 /**
@@ -79,6 +81,23 @@ public class CommandResult {
 
     public Card getTestSessionCard() {
         return testSessionCard;
+    }
+
+    public boolean isAnswerCommand() {
+        if (answerCommandResult == AnswerCommandResultType.NOT_ANSWER_COMMAND) {
+            return false;
+        }
+        return true;
+    }
+
+    public boolean isAnswerCorrect() throws CommandException {
+        if (answerCommandResult == AnswerCommandResultType.ANSWER_CORRECT) {
+            return true;
+        } else if (answerCommandResult == AnswerCommandResultType.ANSWER_WRONG) {
+            return false;
+        } else {
+            throw new CommandException(Messages.MESSAGE_INVALID_ANSWER_COMMAND);
+        }
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/CommandResult.java
+++ b/src/main/java/seedu/address/logic/commands/CommandResult.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.Objects;
 
+import seedu.address.logic.AnswerCommandResultType;
 import seedu.address.model.card.Card;
 
 /**
@@ -25,16 +26,20 @@ public class CommandResult {
     /** The current test session should end. */
     private final boolean endTestSession;
 
+    /** The application should show to user whether answer attempted is correct or wrong. */
+    private final AnswerCommandResultType answerCommandResult;
+
     /**
      * Constructs a {@code CommandResult} with the specified fields.
      */
     public CommandResult(String feedbackToUser, boolean showHelp, boolean exit, Card testSessionCard,
-                         boolean endTestSession) {
+                         boolean endTestSession, AnswerCommandResultType answerCommandResult) {
         this.feedbackToUser = requireNonNull(feedbackToUser);
         this.showHelp = showHelp;
         this.exit = exit;
         this.testSessionCard = testSessionCard;
         this.endTestSession = endTestSession;
+        this.answerCommandResult = answerCommandResult;
     }
 
     /**
@@ -42,7 +47,7 @@ public class CommandResult {
      * and other fields set to their default fullAnswer.
      */
     public CommandResult(String feedbackToUser) {
-        this(feedbackToUser, false, false, null, false);
+        this(feedbackToUser, false, false, null, false, AnswerCommandResultType.NOT_ANSWER_COMMAND);
     }
 
     public String getFeedbackToUser() {
@@ -90,12 +95,15 @@ public class CommandResult {
         CommandResult otherCommandResult = (CommandResult) other;
         return feedbackToUser.equals(otherCommandResult.feedbackToUser)
                 && showHelp == otherCommandResult.showHelp
-                && exit == otherCommandResult.exit;
+                && exit == otherCommandResult.exit
+                && testSessionCard == otherCommandResult.testSessionCard
+                && endTestSession == otherCommandResult.endTestSession
+                && answerCommandResult == otherCommandResult.answerCommandResult;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(feedbackToUser, showHelp, exit, testSessionCard, endTestSession);
+        return Objects.hash(feedbackToUser, showHelp, exit, testSessionCard, endTestSession, answerCommandResult);
     }
 
 }

--- a/src/main/java/seedu/address/logic/commands/CommandResult.java
+++ b/src/main/java/seedu/address/logic/commands/CommandResult.java
@@ -83,6 +83,10 @@ public class CommandResult {
         return testSessionCard;
     }
 
+    /**
+     * Check if command is an ans command
+     * @return a boolean variable to state if command is ans or not
+     */
     public boolean isAnswerCommand() {
         if (answerCommandResult == AnswerCommandResultType.NOT_ANSWER_COMMAND) {
             return false;
@@ -90,6 +94,11 @@ public class CommandResult {
         return true;
     }
 
+    /**
+     * Check if attempted answer is correct or wrong
+     * This method should be called only if a valid ans command is called
+     * @return a boolean variable to state if command is ans or not
+     */
     public boolean isAnswerCorrect() throws CommandException {
         if (answerCommandResult == AnswerCommandResultType.ANSWER_CORRECT) {
             return true;

--- a/src/main/java/seedu/address/logic/commands/EndCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EndCommand.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands;
 
 import seedu.address.commons.core.Messages;
+import seedu.address.logic.AnswerCommandResultType;
 import seedu.address.logic.CommandHistory;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
@@ -21,7 +22,8 @@ public class EndCommand extends Command {
             throw new CommandException(Messages.MESSAGE_INVALID_COMMAND_OUTSIDE_TEST_SESSION);
         }
         model.endTestSession();
-        return new CommandResult(MESSAGE_END_TEST_SESSION_SUCCESS, false, false, null, true);
+        return new CommandResult(MESSAGE_END_TEST_SESSION_SUCCESS, false, false, null, true,
+                AnswerCommandResultType.NOT_ANSWER_COMMAND);
     }
 
 }

--- a/src/main/java/seedu/address/logic/commands/ExitCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExitCommand.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.commands;
 
+import seedu.address.logic.AnswerCommandResultType;
 import seedu.address.logic.CommandHistory;
 import seedu.address.model.Model;
 
@@ -14,7 +15,8 @@ public class ExitCommand extends Command {
 
     @Override
     public CommandResult execute(Model model, CommandHistory history) {
-        return new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, true, null, false);
+        return new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, true, null, false,
+                AnswerCommandResultType.NOT_ANSWER_COMMAND);
     }
 
 }

--- a/src/main/java/seedu/address/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/address/logic/commands/HelpCommand.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.commands;
 
+import seedu.address.logic.AnswerCommandResultType;
 import seedu.address.logic.CommandHistory;
 import seedu.address.model.Model;
 
@@ -17,6 +18,7 @@ public class HelpCommand extends Command {
 
     @Override
     public CommandResult execute(Model model, CommandHistory history) {
-        return new CommandResult(SHOWING_HELP_MESSAGE, true, false, null, false);
+        return new CommandResult(SHOWING_HELP_MESSAGE, true, false, null, false,
+                AnswerCommandResultType.NOT_ANSWER_COMMAND);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/TestCommand.java
+++ b/src/main/java/seedu/address/logic/commands/TestCommand.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
+import seedu.address.logic.AnswerCommandResultType;
 import seedu.address.logic.CommandHistory;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
@@ -48,7 +49,8 @@ public class TestCommand extends Command {
         ReadOnlyCardFolder cardFolderToTest = cardFoldersList.get(targetIndex.getZeroBased());
         model.testCardFolder(cardFolderToTest);
         Card cardToTest = model.getCurrentTestedCard();
-        return new CommandResult(MESSAGE_ENTER_TEST_FOLDER_SUCCESS, false, false, cardToTest, false);
+        return new CommandResult(MESSAGE_ENTER_TEST_FOLDER_SUCCESS, false, false, cardToTest, false,
+                AnswerCommandResultType.NOT_ANSWER_COMMAND);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/TestCommand.java
+++ b/src/main/java/seedu/address/logic/commands/TestCommand.java
@@ -46,7 +46,8 @@ public class TestCommand extends Command {
         }
 
         ReadOnlyCardFolder cardFolderToTest = cardFoldersList.get(targetIndex.getZeroBased());
-        Card cardToTest = model.testCardFolder(cardFolderToTest);
+        model.testCardFolder(cardFolderToTest);
+        Card cardToTest = model.getCurrentTestedCard();
         return new CommandResult(MESSAGE_ENTER_TEST_FOLDER_SUCCESS, false, false, cardToTest, false);
     }
 

--- a/src/main/java/seedu/address/logic/parser/AnswerCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AnswerCommandParser.java
@@ -1,0 +1,28 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.logic.commands.AnswerCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new AnswerCommand object
+ */
+public class AnswerCommandParser implements Parser<AnswerCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the AnswerCommand
+     * and returns an AnswerCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public AnswerCommand parse(String args) throws ParseException {
+        String attemptedAnswer = args.trim();
+        if (attemptedAnswer.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, AnswerCommand.MESSAGE_USAGE));
+        }
+
+        return new AnswerCommand(attemptedAnswer);
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/AnswerCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AnswerCommandParser.java
@@ -4,6 +4,7 @@ import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT
 
 import seedu.address.logic.commands.AnswerCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.card.Answer;
 
 /**
  * Parses input arguments and creates a new AnswerCommand object
@@ -16,13 +17,13 @@ public class AnswerCommandParser implements Parser<AnswerCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public AnswerCommand parse(String args) throws ParseException {
-        String attemptedAnswer = args.trim();
-        if (attemptedAnswer.isEmpty()) {
+        String trimmedArgs = args.trim();
+        if (trimmedArgs.isEmpty()) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, AnswerCommand.MESSAGE_USAGE));
         }
 
-        return new AnswerCommand(attemptedAnswer);
+        return new AnswerCommand(new Answer(trimmedArgs));
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/CommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/CommandParser.java
@@ -7,6 +7,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.AnswerCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
@@ -67,6 +68,9 @@ public class CommandParser {
 
         case TestCommand.COMMAND_WORD:
             return new TestCommandParser().parse(arguments);
+
+        case AnswerCommand.COMMAND_WORD:
+            return new AnswerCommandParser().parse(arguments);
 
         case ClearCommand.COMMAND_WORD:
             return new ClearCommand();

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -169,6 +169,12 @@ public interface Model extends Observable {
     void endTestSession();
 
     /**
+     * Returns true if the given answer is right
+     * false if answer is wrong
+     */
+    public boolean markAttemptedAnswer(String attemptedAnswer);
+
+    /**
      * Checks whether list of card folder names specified is found inside model
      */
     boolean checkValidCardFolders(List<String> cardFolers);

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -188,5 +188,5 @@ public interface Model extends Observable {
     /**
      * Checks whether list of card folder names specified is found inside model
      */
-    boolean checkValidCardFolders(List<String> cardFolers);
+    boolean checkValidCardFolders(List<String> cardFolders);
 }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -163,6 +163,12 @@ public interface Model extends Observable {
     public void setCurrentTestedCard(Card card);
 
     /**
+     * Returns the current card in the test session
+     * null if there is no cards in folder or user is not in a test session.
+     */
+    public Card getCurrentTestedCard();
+
+    /**
      * Returns true if user is in a test session
      * false user is not.
      */

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -158,6 +158,11 @@ public interface Model extends Observable {
     Card testCardFolder(ReadOnlyCardFolder cardFolder);
 
     /**
+     * Sets the current card in the test session.
+     */
+    public void setCurrentTestedCard(Card card);
+
+    /**
      * Returns true if user is in a test session
      * false user is not.
      */

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -154,6 +154,11 @@ public interface Model extends Observable {
     void setSelectedCard(Card card);
 
     /**
+     * Checks whether list of card folder names specified is found inside model
+     */
+    boolean checkValidCardFolders(List<String> cardFolders);
+
+    /**
      * Enters a test session using the specified card folder.
      */
     void testCardFolder(ReadOnlyCardFolder cardFolder);
@@ -197,8 +202,4 @@ public interface Model extends Observable {
      */
     boolean checkIfCardAlreadyAnswered();
 
-    /**
-     * Checks whether list of card folder names specified is found inside model
-     */
-    boolean checkValidCardFolders(List<String> cardFolders);
 }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -8,6 +8,7 @@ import javafx.beans.Observable;
 import javafx.beans.property.ReadOnlyProperty;
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
+import seedu.address.model.card.Answer;
 import seedu.address.model.card.Card;
 
 /**
@@ -183,7 +184,7 @@ public interface Model extends Observable {
      * Returns true if the given answer is right
      * false if answer is wrong
      */
-    boolean markAttemptedAnswer(String attemptedAnswer);
+    boolean markAttemptedAnswer(Answer attemptedAnswer);
 
     /**
      * Checks whether list of card folder names specified is found inside model

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -187,6 +187,17 @@ public interface Model extends Observable {
     boolean markAttemptedAnswer(Answer attemptedAnswer);
 
     /**
+     * Set cardAlreadyAnswered variable to true to indicate current card as answered
+     */
+    void setCardAsAnswered();
+
+    /**
+     * Returns true if the answer has already been input for that card
+     * false if otherwise
+     */
+    boolean checkIfCardAlreadyAnswered();
+
+    /**
      * Checks whether list of card folder names specified is found inside model
      */
     boolean checkValidCardFolders(List<String> cardFolders);

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -155,18 +155,18 @@ public interface Model extends Observable {
     /**
      * Enters a test session using the specified card folder.
      */
-    Card testCardFolder(ReadOnlyCardFolder cardFolder);
+    void testCardFolder(ReadOnlyCardFolder cardFolder);
 
     /**
      * Sets the current card in the test session.
      */
-    public void setCurrentTestedCard(Card card);
+    void setCurrentTestedCard(Card card);
 
     /**
      * Returns the current card in the test session
      * null if there is no cards in folder or user is not in a test session.
      */
-    public Card getCurrentTestedCard();
+    Card getCurrentTestedCard();
 
     /**
      * Returns true if user is in a test session
@@ -183,7 +183,7 @@ public interface Model extends Observable {
      * Returns true if the given answer is right
      * false if answer is wrong
      */
-    public boolean markAttemptedAnswer(String attemptedAnswer);
+    boolean markAttemptedAnswer(String attemptedAnswer);
 
     /**
      * Checks whether list of card folder names specified is found inside model

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -160,6 +160,12 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public boolean markAttemptedAnswer(String attemptedAnswer) {
+
+        return false;
+    }
+
+    @Override
     public boolean checkValidCardFolders(List<String> cardFolers) {
         return false;
     }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -143,12 +143,11 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public Card testCardFolder(ReadOnlyCardFolder cardFolderToTest) {
+    public void testCardFolder(ReadOnlyCardFolder cardFolderToTest) {
         //TODO: Remove hardcoding, enter card folder and get the list of cards, enter test session mode
         Card cardToTest = cardFolderToTest.getCardList().get(0);
         setCurrentTestedCard(cardToTest);
         insideTestSession = true;
-        return cardToTest;
     }
 
     @Override
@@ -172,6 +171,7 @@ public class ModelManager implements Model {
     @Override
     public void endTestSession() {
         insideTestSession = false;
+        setCurrentTestedCard(null);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -38,6 +38,7 @@ public class ModelManager implements Model {
     private final SimpleObjectProperty<Card> selectedCard = new SimpleObjectProperty<>();
     private final SimpleObjectProperty<Card> currentTestedCard = new SimpleObjectProperty<>();
     private boolean insideTestSession = false;
+    private boolean cardAlreadyAnswered = false;
     private final InvalidationListenerManager invalidationListenerManager = new InvalidationListenerManager();
 
     /**
@@ -182,12 +183,20 @@ public class ModelManager implements Model {
         String attemptedAnswerInCapitals = attemptedAnswer.toString().toUpperCase();
 
         //LOOSEN MORE CRITERIAS?
-
         if (correctAnswerInCapitals.equals(attemptedAnswerInCapitals)) {
             return true;
         }
-
         return false;
+    }
+
+    @Override
+    public void setCardAsAnswered() {
+        cardAlreadyAnswered = true;
+    }
+
+    @Override
+    public boolean checkIfCardAlreadyAnswered() {
+        return cardAlreadyAnswered;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -292,6 +292,7 @@ public class ModelManager implements Model {
     @Override
     public void endTestSession() {
         insideTestSession = false;
+        cardAlreadyAnswered = false;
         setCurrentTestedCard(null);
     }
 

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -181,7 +181,7 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public boolean checkValidCardFolders(List<String> cardFolers) {
+    public boolean checkValidCardFolders(List<String> cardFolders) {
         return false;
     }
 

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -21,6 +21,7 @@ import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.util.InvalidationListenerManager;
+import seedu.address.model.card.Answer;
 import seedu.address.model.card.Card;
 import seedu.address.model.card.exceptions.CardNotFoundException;
 
@@ -175,7 +176,16 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public boolean markAttemptedAnswer(String attemptedAnswer) {
+    public boolean markAttemptedAnswer(Answer attemptedAnswer) {
+        Answer correctAnswer = currentTestedCard.getValue().getAnswer();
+        String correctAnswerInCapitals = correctAnswer.toString().toUpperCase();
+        String attemptedAnswerInCapitals = attemptedAnswer.toString().toUpperCase();
+
+        //LOOSEN MORE CRITERIAS?
+
+        if (correctAnswerInCapitals.equals(attemptedAnswerInCapitals)) {
+            return true;
+        }
 
         return false;
     }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -35,6 +35,7 @@ public class ModelManager implements Model {
     private final UserPrefs userPrefs;
     private final List<FilteredList<Card>> filteredCardsList;
     private final SimpleObjectProperty<Card> selectedCard = new SimpleObjectProperty<>();
+    private final SimpleObjectProperty<Card> currentTestedCard = new SimpleObjectProperty<>();
     private boolean insideTestSession = false;
     private final InvalidationListenerManager invalidationListenerManager = new InvalidationListenerManager();
 
@@ -145,8 +146,17 @@ public class ModelManager implements Model {
     public Card testCardFolder(ReadOnlyCardFolder cardFolderToTest) {
         //TODO: Remove hardcoding, enter card folder and get the list of cards, enter test session mode
         Card cardToTest = cardFolderToTest.getCardList().get(0);
+        setCurrentTestedCard(cardToTest);
         insideTestSession = true;
         return cardToTest;
+    }
+
+    @Override
+    public void setCurrentTestedCard(Card card) {
+        if (card != null && !getActiveFilteredCards().contains(card)) {
+            throw new CardNotFoundException();
+        }
+        currentTestedCard.setValue(card);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -145,61 +145,6 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public void testCardFolder(ReadOnlyCardFolder cardFolderToTest) {
-        //TODO: Remove hardcoding, enter card folder and get the list of cards, enter test session mode
-        Card cardToTest = cardFolderToTest.getCardList().get(0);
-        setCurrentTestedCard(cardToTest);
-        insideTestSession = true;
-    }
-
-    @Override
-    public void setCurrentTestedCard(Card card) {
-        if (card != null && !getActiveFilteredCards().contains(card)) {
-            throw new CardNotFoundException();
-        }
-        currentTestedCard.setValue(card);
-    }
-
-    @Override
-    public Card getCurrentTestedCard() {
-        return currentTestedCard.getValue();
-    }
-
-    @Override
-    public boolean checkIfInsideTestSession() {
-        return insideTestSession;
-    }
-
-    @Override
-    public void endTestSession() {
-        insideTestSession = false;
-        setCurrentTestedCard(null);
-    }
-
-    @Override
-    public boolean markAttemptedAnswer(Answer attemptedAnswer) {
-        Answer correctAnswer = currentTestedCard.getValue().getAnswer();
-        String correctAnswerInCapitals = correctAnswer.toString().toUpperCase();
-        String attemptedAnswerInCapitals = attemptedAnswer.toString().toUpperCase();
-
-        //LOOSEN MORE CRITERIAS?
-        if (correctAnswerInCapitals.equals(attemptedAnswerInCapitals)) {
-            return true;
-        }
-        return false;
-    }
-
-    @Override
-    public void setCardAsAnswered() {
-        cardAlreadyAnswered = true;
-    }
-
-    @Override
-    public boolean checkIfCardAlreadyAnswered() {
-        return cardAlreadyAnswered;
-    }
-
-    @Override
     public boolean checkValidCardFolders(List<String> cardFolders) {
         return false;
     }
@@ -314,6 +259,63 @@ public class ModelManager implements Model {
     public void commitActiveCardFolder() {
         VersionedCardFolder versionedCardFolder = getActiveVersionedCardFolder();
         versionedCardFolder.commit();
+    }
+
+    //=========== Test Session ===========================================================================
+
+    @Override
+    public void testCardFolder(ReadOnlyCardFolder cardFolderToTest) {
+        //TODO: Remove hardcoding, enter card folder and get the list of cards, enter test session mode
+        Card cardToTest = cardFolderToTest.getCardList().get(0);
+        setCurrentTestedCard(cardToTest);
+        insideTestSession = true;
+    }
+
+    @Override
+    public void setCurrentTestedCard(Card card) {
+        if (card != null && !getActiveFilteredCards().contains(card)) {
+            throw new CardNotFoundException();
+        }
+        currentTestedCard.setValue(card);
+    }
+
+    @Override
+    public Card getCurrentTestedCard() {
+        return currentTestedCard.getValue();
+    }
+
+    @Override
+    public boolean checkIfInsideTestSession() {
+        return insideTestSession;
+    }
+
+    @Override
+    public void endTestSession() {
+        insideTestSession = false;
+        setCurrentTestedCard(null);
+    }
+
+    @Override
+    public boolean markAttemptedAnswer(Answer attemptedAnswer) {
+        Answer correctAnswer = currentTestedCard.getValue().getAnswer();
+        String correctAnswerInCapitals = correctAnswer.toString().toUpperCase();
+        String attemptedAnswerInCapitals = attemptedAnswer.toString().toUpperCase();
+
+        //LOOSEN MORE CRITERIAS?
+        if (correctAnswerInCapitals.equals(attemptedAnswerInCapitals)) {
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public void setCardAsAnswered() {
+        cardAlreadyAnswered = true;
+    }
+
+    @Override
+    public boolean checkIfCardAlreadyAnswered() {
+        return cardAlreadyAnswered;
     }
 
     //=========== Selected card ===========================================================================

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -160,6 +160,11 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public Card getCurrentTestedCard() {
+        return currentTestedCard.getValue();
+    }
+
+    @Override
     public boolean checkIfInsideTestSession() {
         return insideTestSession;
     }

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -186,6 +186,20 @@ public class MainWindow extends UiPart<Stage> {
         fullScreenPlaceholder.getChildren().remove(fullScreenPlaceholder.getChildren().size() - 1);
     }
 
+    /**
+     * Show the page with correct answer.
+     */
+    private void handleCorrectAnswer() {
+        //TODO: Change UI to display correct answer
+    }
+
+    /**
+     * Show the page with wrong answer.
+     */
+    private void handleWrongAnswer() {
+        //TODO: Change UI to display wrong answer
+    }
+
     public CardListPanel getCardListPanel() {
         return cardListPanel;
     }
@@ -215,6 +229,14 @@ public class MainWindow extends UiPart<Stage> {
 
             if (commandResult.isEndTestSession()) {
                 handleEndTestSession();
+            }
+
+            if (commandResult.isAnswerCommand()) {
+                if (commandResult.isAnswerCorrect()) {
+                    handleCorrectAnswer();
+                } else {
+                    handleWrongAnswer();
+                }
             }
 
             return commandResult;

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -26,6 +26,7 @@ import seedu.address.model.CardFolder;
 import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyCardFolder;
 import seedu.address.model.ReadOnlyUserPrefs;
+import seedu.address.model.card.Answer;
 import seedu.address.model.card.Card;
 import seedu.address.testutil.CardBuilder;
 
@@ -172,7 +173,7 @@ public class AddCommandTest {
         }
 
         @Override
-        public boolean markAttemptedAnswer(String attemptedAnswer) { throw new AssertionError("This method should not be called."); }
+        public boolean markAttemptedAnswer(Answer attemptedAnswer) { throw new AssertionError("This method should not be called."); }
 
         @Override
         public boolean checkValidCardFolders(List<String> cardFolders) {

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -176,6 +176,12 @@ public class AddCommandTest {
         public boolean markAttemptedAnswer(Answer attemptedAnswer) { throw new AssertionError("This method should not be called."); }
 
         @Override
+        public void setCardAsAnswered() { throw new AssertionError("This method should not be called."); }
+
+        @Override
+        public boolean checkIfCardAlreadyAnswered() { throw new AssertionError("This method should not be called."); }
+
+        @Override
         public boolean checkValidCardFolders(List<String> cardFolders) {
             return false;
         }

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -173,13 +173,19 @@ public class AddCommandTest {
         }
 
         @Override
-        public boolean markAttemptedAnswer(Answer attemptedAnswer) { throw new AssertionError("This method should not be called."); }
+        public boolean markAttemptedAnswer(Answer attemptedAnswer) {
+            throw new AssertionError("This method should not be called.");
+        }
 
         @Override
-        public void setCardAsAnswered() { throw new AssertionError("This method should not be called."); }
+        public void setCardAsAnswered() {
+            throw new AssertionError("This method should not be called.");
+        }
 
         @Override
-        public boolean checkIfCardAlreadyAnswered() { throw new AssertionError("This method should not be called."); }
+        public boolean checkIfCardAlreadyAnswered() {
+            throw new AssertionError("This method should not be called.");
+        }
 
         @Override
         public boolean checkValidCardFolders(List<String> cardFolders) {

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -146,9 +146,20 @@ public class AddCommandTest {
         }
 
         @Override
-        public Card testCardFolder(ReadOnlyCardFolder cardFolderToTest) {
+        public void testCardFolder(ReadOnlyCardFolder cardFolderToTest) {
             throw new AssertionError("This method should not be called.");
         }
+
+        @Override
+        public Card getCurrentTestedCard() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setCurrentTestedCard(Card card) {
+            throw new AssertionError("This method should not be called.");
+        }
+
 
         @Override
         public boolean checkIfInsideTestSession() {
@@ -161,7 +172,10 @@ public class AddCommandTest {
         }
 
         @Override
-        public boolean checkValidCardFolders(List<String> cardFolers) {
+        public boolean markAttemptedAnswer(String attemptedAnswer) { throw new AssertionError("This method should not be called."); }
+
+        @Override
+        public boolean checkValidCardFolders(List<String> cardFolders) {
             return false;
         }
 

--- a/src/test/java/seedu/address/logic/commands/CommandResultTest.java
+++ b/src/test/java/seedu/address/logic/commands/CommandResultTest.java
@@ -19,7 +19,8 @@ public class CommandResultTest {
 
         // same values -> returns true
         assertTrue(commandResult.equals(new CommandResult("feedback")));
-        assertTrue(commandResult.equals(new CommandResult("feedback", false, false, null, false, AnswerCommandResultType.NOT_ANSWER_COMMAND)));
+        assertTrue(commandResult.equals(new CommandResult("feedback", false, false,
+                null, false, AnswerCommandResultType.NOT_ANSWER_COMMAND)));
 
         // same object -> returns true
         assertTrue(commandResult.equals(commandResult));
@@ -33,26 +34,26 @@ public class CommandResultTest {
         // different feedbackToUser fullAnswer -> returns false
         assertFalse(commandResult.equals(new CommandResult("different")));
         // different showHelp value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("feedback", true, false, null, false,
-                AnswerCommandResultType.NOT_ANSWER_COMMAND)));
+        assertFalse(commandResult.equals(new CommandResult("feedback", true, false,
+                null, false, AnswerCommandResultType.NOT_ANSWER_COMMAND)));
 
         // different exit value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("feedback", false, true, null, false,
-                AnswerCommandResultType.NOT_ANSWER_COMMAND)));
+        assertFalse(commandResult.equals(new CommandResult("feedback", false, true,
+                null, false, AnswerCommandResultType.NOT_ANSWER_COMMAND)));
 
         // different testSessionCard value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("feedback", false, false, sampleTestCard, false,
-                AnswerCommandResultType.NOT_ANSWER_COMMAND)));
+        assertFalse(commandResult.equals(new CommandResult("feedback", false, false,
+                sampleTestCard, false, AnswerCommandResultType.NOT_ANSWER_COMMAND)));
 
         // different endTestSession value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("feedback", false, false, null, true,
-                AnswerCommandResultType.NOT_ANSWER_COMMAND)));
+        assertFalse(commandResult.equals(new CommandResult("feedback", false, false,
+                null, true, AnswerCommandResultType.NOT_ANSWER_COMMAND)));
 
         // different AnswerCommandResult value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("feedback", false, false, null, false,
-                AnswerCommandResultType.ANSWER_CORRECT)));
-        assertFalse(commandResult.equals(new CommandResult("feedback", false, false, null, false,
-                AnswerCommandResultType.ANSWER_WRONG)));
+        assertFalse(commandResult.equals(new CommandResult("feedback", false, false,
+                null, false, AnswerCommandResultType.ANSWER_CORRECT)));
+        assertFalse(commandResult.equals(new CommandResult("feedback", false, false,
+                null, false, AnswerCommandResultType.ANSWER_WRONG)));
     }
 
     @Test
@@ -67,25 +68,25 @@ public class CommandResultTest {
         assertNotEquals(commandResult.hashCode(), new CommandResult("different").hashCode());
 
         // different showHelp value -> returns different hashcode
-        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", true, false, null, false,
-                AnswerCommandResultType.NOT_ANSWER_COMMAND).hashCode());
+        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", true, false,
+                null, false, AnswerCommandResultType.NOT_ANSWER_COMMAND).hashCode());
 
         // different exit value -> returns different hashcode
-        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false, true, null, false,
-                AnswerCommandResultType.NOT_ANSWER_COMMAND).hashCode());
+        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false, true,
+                null, false, AnswerCommandResultType.NOT_ANSWER_COMMAND).hashCode());
 
         // different testSessionCard value -> returns different hashcode
-        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false, false, sampleTestCard, false,
-                AnswerCommandResultType.NOT_ANSWER_COMMAND).hashCode());
+        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false, false,
+                sampleTestCard, false, AnswerCommandResultType.NOT_ANSWER_COMMAND).hashCode());
 
         // different endTestSession value -> returns different hashcode
-        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false, false, null, true,
-                AnswerCommandResultType.NOT_ANSWER_COMMAND).hashCode());
+        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false, false,
+                null, true, AnswerCommandResultType.NOT_ANSWER_COMMAND).hashCode());
 
         // different AnswerCommandResult value -> returns different hashcode
-        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false, false, null, false,
-                AnswerCommandResultType.ANSWER_CORRECT).hashCode());
-        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false, false, null, false,
-                AnswerCommandResultType.ANSWER_WRONG).hashCode());
+        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false, false,
+                null, false, AnswerCommandResultType.ANSWER_CORRECT).hashCode());
+        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false, false,
+                null, false, AnswerCommandResultType.ANSWER_WRONG).hashCode());
     }
 }

--- a/src/test/java/seedu/address/logic/commands/CommandResultTest.java
+++ b/src/test/java/seedu/address/logic/commands/CommandResultTest.java
@@ -7,6 +7,8 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
+import seedu.address.logic.AnswerCommandResultType;
+
 public class CommandResultTest {
     @Test
     public void equals() {
@@ -14,7 +16,7 @@ public class CommandResultTest {
 
         // same values -> returns true
         assertTrue(commandResult.equals(new CommandResult("feedback")));
-        assertTrue(commandResult.equals(new CommandResult("feedback", false, false, null, false)));
+        assertTrue(commandResult.equals(new CommandResult("feedback", false, false, null, false, AnswerCommandResultType.NOT_ANSWER_COMMAND)));
 
         // same object -> returns true
         assertTrue(commandResult.equals(commandResult));
@@ -28,10 +30,12 @@ public class CommandResultTest {
         // different feedbackToUser fullAnswer -> returns false
         assertFalse(commandResult.equals(new CommandResult("different")));
         // different showHelp value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("feedback", true, false, null, false)));
+        assertFalse(commandResult.equals(new CommandResult("feedback", true, false, null, false,
+                AnswerCommandResultType.NOT_ANSWER_COMMAND)));
 
         // different exit value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("feedback", false, true, null, false)));
+        assertFalse(commandResult.equals(new CommandResult("feedback", false, true, null, false,
+                AnswerCommandResultType.NOT_ANSWER_COMMAND)));
     }
 
     @Test
@@ -45,9 +49,11 @@ public class CommandResultTest {
         assertNotEquals(commandResult.hashCode(), new CommandResult("different").hashCode());
 
         // different showHelp value -> returns different hashcode
-        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", true, false, null, false).hashCode());
+        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", true, false, null, false,
+                AnswerCommandResultType.NOT_ANSWER_COMMAND).hashCode());
 
         // different exit value -> returns different hashcode
-        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false, true, null, false).hashCode());
+        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false, true, null, false,
+                AnswerCommandResultType.NOT_ANSWER_COMMAND).hashCode());
     }
 }

--- a/src/test/java/seedu/address/logic/commands/CommandResultTest.java
+++ b/src/test/java/seedu/address/logic/commands/CommandResultTest.java
@@ -8,11 +8,14 @@ import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 
 import seedu.address.logic.AnswerCommandResultType;
+import seedu.address.model.card.Card;
+import seedu.address.testutil.CardBuilder;
 
 public class CommandResultTest {
     @Test
     public void equals() {
         CommandResult commandResult = new CommandResult("feedback");
+        Card sampleTestCard = new CardBuilder().build();
 
         // same values -> returns true
         assertTrue(commandResult.equals(new CommandResult("feedback")));
@@ -36,11 +39,26 @@ public class CommandResultTest {
         // different exit value -> returns false
         assertFalse(commandResult.equals(new CommandResult("feedback", false, true, null, false,
                 AnswerCommandResultType.NOT_ANSWER_COMMAND)));
+
+        // different testSessionCard value -> returns false
+        assertFalse(commandResult.equals(new CommandResult("feedback", false, false, sampleTestCard, false,
+                AnswerCommandResultType.NOT_ANSWER_COMMAND)));
+
+        // different endTestSession value -> returns false
+        assertFalse(commandResult.equals(new CommandResult("feedback", false, false, null, true,
+                AnswerCommandResultType.NOT_ANSWER_COMMAND)));
+
+        // different AnswerCommandResult value -> returns false
+        assertFalse(commandResult.equals(new CommandResult("feedback", false, false, null, false,
+                AnswerCommandResultType.ANSWER_CORRECT)));
+        assertFalse(commandResult.equals(new CommandResult("feedback", false, false, null, false,
+                AnswerCommandResultType.ANSWER_WRONG)));
     }
 
     @Test
     public void hashcode() {
         CommandResult commandResult = new CommandResult("feedback");
+        Card sampleTestCard = new CardBuilder().build();
 
         // same values -> returns same hashcode
         assertEquals(commandResult.hashCode(), new CommandResult("feedback").hashCode());
@@ -55,5 +73,19 @@ public class CommandResultTest {
         // different exit value -> returns different hashcode
         assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false, true, null, false,
                 AnswerCommandResultType.NOT_ANSWER_COMMAND).hashCode());
+
+        // different testSessionCard value -> returns different hashcode
+        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false, false, sampleTestCard, false,
+                AnswerCommandResultType.NOT_ANSWER_COMMAND).hashCode());
+
+        // different endTestSession value -> returns different hashcode
+        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false, false, null, true,
+                AnswerCommandResultType.NOT_ANSWER_COMMAND).hashCode());
+
+        // different AnswerCommandResult value -> returns different hashcode
+        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false, false, null, false,
+                AnswerCommandResultType.ANSWER_CORRECT).hashCode());
+        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false, false, null, false,
+                AnswerCommandResultType.ANSWER_WRONG).hashCode());
     }
 }

--- a/src/test/java/seedu/address/logic/commands/ExitCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ExitCommandTest.java
@@ -5,6 +5,7 @@ import static seedu.address.logic.commands.ExitCommand.MESSAGE_EXIT_ACKNOWLEDGEM
 
 import org.junit.Test;
 
+import seedu.address.logic.AnswerCommandResultType;
 import seedu.address.logic.CommandHistory;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
@@ -16,7 +17,8 @@ public class ExitCommandTest {
 
     @Test
     public void execute_exit_success() {
-        CommandResult expectedCommandResult = new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, true, null, false);
+        CommandResult expectedCommandResult = new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, true, null, false,
+                AnswerCommandResultType.NOT_ANSWER_COMMAND);
         assertCommandSuccess(new ExitCommand(), model, commandHistory, expectedCommandResult, expectedModel);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/ExitCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ExitCommandTest.java
@@ -17,8 +17,8 @@ public class ExitCommandTest {
 
     @Test
     public void execute_exit_success() {
-        CommandResult expectedCommandResult = new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, true, null, false,
-                AnswerCommandResultType.NOT_ANSWER_COMMAND);
+        CommandResult expectedCommandResult = new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, true,
+                null, false, AnswerCommandResultType.NOT_ANSWER_COMMAND);
         assertCommandSuccess(new ExitCommand(), model, commandHistory, expectedCommandResult, expectedModel);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/HelpCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/HelpCommandTest.java
@@ -17,8 +17,8 @@ public class HelpCommandTest {
 
     @Test
     public void execute_help_success() {
-        CommandResult expectedCommandResult = new CommandResult(SHOWING_HELP_MESSAGE, true, false, null, false,
-                AnswerCommandResultType.NOT_ANSWER_COMMAND);
+        CommandResult expectedCommandResult = new CommandResult(SHOWING_HELP_MESSAGE, true, false,
+                null, false, AnswerCommandResultType.NOT_ANSWER_COMMAND);
         assertCommandSuccess(new HelpCommand(), model, commandHistory, expectedCommandResult, expectedModel);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/HelpCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/HelpCommandTest.java
@@ -5,6 +5,7 @@ import static seedu.address.logic.commands.HelpCommand.SHOWING_HELP_MESSAGE;
 
 import org.junit.Test;
 
+import seedu.address.logic.AnswerCommandResultType;
 import seedu.address.logic.CommandHistory;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
@@ -16,7 +17,8 @@ public class HelpCommandTest {
 
     @Test
     public void execute_help_success() {
-        CommandResult expectedCommandResult = new CommandResult(SHOWING_HELP_MESSAGE, true, false, null, false);
+        CommandResult expectedCommandResult = new CommandResult(SHOWING_HELP_MESSAGE, true, false, null, false,
+                AnswerCommandResultType.NOT_ANSWER_COMMAND);
         assertCommandSuccess(new HelpCommand(), model, commandHistory, expectedCommandResult, expectedModel);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AnswerCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AnswerCommandParserTest.java
@@ -15,7 +15,8 @@ public class AnswerCommandParserTest {
 
     @Test
     public void parse_emptyArg_throwsParseException() {
-        assertParseFailure(parser, "     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT, AnswerCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                AnswerCommand.MESSAGE_USAGE));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/AnswerCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AnswerCommandParserTest.java
@@ -1,0 +1,28 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.Test;
+
+import seedu.address.logic.commands.AnswerCommand;
+
+public class AnswerCommandParserTest {
+
+    private AnswerCommandParser parser = new AnswerCommandParser();
+
+    @Test
+    public void parse_emptyArg_throwsParseException() {
+        assertParseFailure(parser, "     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT, AnswerCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_validArgs_returnsFindCommand() {
+        // no leading and trailing whitespaces
+        AnswerCommand expectedAnswerCommand =
+                new AnswerCommand("Golgi apparatus");
+        assertParseSuccess(parser, "Golgi apparatus ", expectedAnswerCommand);
+    }
+
+}

--- a/src/test/java/seedu/address/logic/parser/AnswerCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AnswerCommandParserTest.java
@@ -7,6 +7,7 @@ import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSucces
 import org.junit.Test;
 
 import seedu.address.logic.commands.AnswerCommand;
+import seedu.address.model.card.Answer;
 
 public class AnswerCommandParserTest {
 
@@ -21,7 +22,7 @@ public class AnswerCommandParserTest {
     public void parse_validArgs_returnsFindCommand() {
         // no leading and trailing whitespaces
         AnswerCommand expectedAnswerCommand =
-                new AnswerCommand("Golgi apparatus");
+                new AnswerCommand(new Answer("Golgi apparatus"));
         assertParseSuccess(parser, "Golgi apparatus ", expectedAnswerCommand);
     }
 

--- a/src/test/java/seedu/address/logic/parser/CommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/CommandParserTest.java
@@ -32,6 +32,7 @@ import seedu.address.logic.commands.SelectCommand;
 import seedu.address.logic.commands.TestCommand;
 import seedu.address.logic.commands.UndoCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.card.Answer;
 import seedu.address.model.card.Card;
 import seedu.address.model.card.QuestionContainsKeywordsPredicate;
 import seedu.address.testutil.CardBuilder;
@@ -73,10 +74,10 @@ public class CommandParserTest {
 
     @Test
     public void parseCommand_answer() throws Exception {
-        String attemptedAnswer = "foo";
+        String attemptedAnswerInput = "foo";
         AnswerCommand command = (AnswerCommand) parser.parseCommand(
-                AnswerCommand.COMMAND_WORD + " " + attemptedAnswer);
-        assertEquals(new AnswerCommand(attemptedAnswer), command);
+                AnswerCommand.COMMAND_WORD + " " + attemptedAnswerInput);
+        assertEquals(new AnswerCommand(new Answer(attemptedAnswerInput)), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/CommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/CommandParserTest.java
@@ -16,6 +16,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.AnswerCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
@@ -71,6 +72,14 @@ public class CommandParserTest {
     }
 
     @Test
+    public void parseCommand_answer() throws Exception {
+        String attemptedAnswer = "foo";
+        AnswerCommand command = (AnswerCommand) parser.parseCommand(
+                AnswerCommand.COMMAND_WORD + " " + attemptedAnswer);
+        assertEquals(new AnswerCommand(attemptedAnswer), command);
+    }
+
+    @Test
     public void parseCommand_edit() throws Exception {
         Card card = new CardBuilder().build();
         EditCardDescriptor descriptor = new EditCardDescriptorBuilder(card).build();
@@ -92,7 +101,7 @@ public class CommandParserTest {
     }
 
     @Test
-    public void parseCommand_find() throws Exception {
+    public void parseCommand_search() throws Exception {
         List<String> keywords = Arrays.asList("foo", "bar", "baz");
         SearchCommand command = (SearchCommand) parser.parseCommand(
                 SearchCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")));

--- a/src/test/java/seedu/address/testutil/CardBuilder.java
+++ b/src/test/java/seedu/address/testutil/CardBuilder.java
@@ -15,8 +15,8 @@ import seedu.address.model.util.SampleDataUtil;
  */
 public class CardBuilder {
 
-    public static final String DEFAULT_NAME = "Alice Pauline";
-    public static final String DEFAULT_ANSWER = "85355255";
+    public static final String DEFAULT_QUESTION = "What is the powerhouse of a cell?";
+    public static final String DEFAULT_ANSWER = "Mitochondrion";
     public static final String DEFAULT_SCORE = "0/0";
 
     private Question question;
@@ -25,7 +25,7 @@ public class CardBuilder {
     private Set<Hint> hints;
 
     public CardBuilder() {
-        question = new Question(DEFAULT_NAME);
+        question = new Question(DEFAULT_QUESTION);
         answer = new Answer(DEFAULT_ANSWER);
         score = new Score(DEFAULT_SCORE);
         hints = new HashSet<>();


### PR DESCRIPTION
- Add ans command
- Add ans command parser test
- Create new currentTestedCard variable to keep track of card in the current test session
- Mark attempted answer with the correct answer in model
- Check ans command is valid only in a test session
- Check ans command is valid only when a question is displayed (so when user already answered once and be presented with the correct/wrong page, user cannot type ans again until it goes to the next card)
- Update CommandResult to accept new enum parameter AnswerCommandResultType for linking correct/wrong answer in Logic to changes in UI (currently incomplete)
- Call method to update score for the card

To add in the future:

- test/end/ans command tests
- To update changes in UI depending on correct or wrong answer (link to matthew's part)
- Reset cardAlreadyAnswered value in model when next command is implemented
- GUI tests